### PR TITLE
Add a split_n convenience method to ArgumentValue and ArgumentValues.

### DIFF
--- a/examples/area/area.cpp
+++ b/examples/area/area.cpp
@@ -42,7 +42,7 @@ int main(int argc, char* argv[])
     std::vector<Point> corners;
     for (auto value : args.values("X,Y"))
     {
-        auto coordinates = value.split(',', 2, 2).as_doubles();
+        auto coordinates = value.split_n(',', 2).as_doubles();
         corners.push_back({coordinates[0], coordinates[1]});
     }
 

--- a/include/Argos/ArgumentValue.hpp
+++ b/include/Argos/ArgumentValue.hpp
@@ -242,7 +242,7 @@ namespace argos
 
         /**
          * @brief Splits the string from the command line on @a separator and
-         *      returns the resulting parts.
+         *  returns the resulting parts.
          *
          * An error message is displayed if the result has less than
          * @a min_parts parts (i.e. number of separators is less than
@@ -254,10 +254,29 @@ namespace argos
          * limit to the number of parts.
          *
          * @throw ArgosException if @a auto_exit is false and the result
-         *      has less than @a min_parts parts.
+         *  has less than @a min_parts parts.
          */
         [[nodiscard]] ArgumentValues
         split(char separator, size_t min_parts = 0, size_t max_parts = 0) const;
+
+
+        /**
+         * @brief Splits the string from the command line on @a separator into
+         *  exactly @a num_parts parts and returns them.
+         *
+         * An error message is displayed if the result has less than
+         * @a num_parts parts (i.e. number of separators is less than
+         * num_parts - 1). If there are more occurrences of @a separator, they
+         * will be included in the last part.
+         *
+         * @note This function is equivalent to calling
+         *  `split(separator, num_parts, num_parts)`.
+         *
+         * @throw ArgosException if @a auto_exit is false and the result
+         *  has less than @a min_parts parts.
+         */
+        [[nodiscard]] ArgumentValues
+        split_n(char separator, size_t num_parts) const;
 
         /**
          * Display @a message as if it was an error produced within Argos

--- a/include/Argos/ArgumentValues.hpp
+++ b/include/Argos/ArgumentValues.hpp
@@ -286,6 +286,22 @@ namespace argos
         split(char separator, size_t min_parts = 0, size_t max_parts = 0) const;
 
         /**
+         * @brief Splits each value on @a separator into exactly @a num_parts
+         *  parts and returns the result.
+         *
+         * @note This function is equivalent to calling
+         *  `split(separator, num_parts, num_parts)`.
+         *
+         * @param separator The separator.
+         * @param num_parts The number of parts each value must
+         *  consist of.
+         * @throw ArgosException if any value consists of less than
+         *  @a num_parts parts.
+         */
+        [[nodiscard]] ArgumentValues
+        split_n(char separator, size_t num_parts) const;
+
+        /**
          * @brief Returns an iterator pointing to the first value.
          */
         [[nodiscard]] ArgumentValueIterator begin() const;

--- a/single_src/Argos/Argos.cpp
+++ b/single_src/Argos/Argos.cpp
@@ -834,10 +834,15 @@ namespace argos
         ERROR
     };
 
+    using IteratorResultData = std::variant<
+        std::monostate,
+        const ArgumentData*,
+        const OptionData*>;
+
     using IteratorResult = std::tuple<
-            IteratorResultCode,
-            const void*,
-            std::string_view>;
+        IteratorResultCode,
+        IteratorResultData,
+        std::string_view>;
 
     class ArgumentIteratorImpl
     {
@@ -853,6 +858,7 @@ namespace argos
 
         [[nodiscard]] const std::shared_ptr<ParsedArgumentsImpl>&
         parsed_arguments() const;
+
     private:
         enum class OptionResult
         {
@@ -883,6 +889,7 @@ namespace argos
         std::shared_ptr<ParsedArgumentsImpl> m_parsed_args;
         std::unique_ptr<IOptionIterator> m_iterator;
         ArgumentCounter m_argument_counter;
+
         enum class State
         {
             ARGUMENTS_AND_OPTIONS,
@@ -890,6 +897,7 @@ namespace argos
             DONE,
             ERROR
         };
+
         State m_state = State::ARGUMENTS_AND_OPTIONS;
     };
 }
@@ -931,12 +939,12 @@ namespace argos
         {
         case IteratorResultCode::ARGUMENT:
             arg = std::make_unique<ArgumentView>(
-                    static_cast<const ArgumentData*>(std::get<1>(res)));
+                    std::get<const ArgumentData*>(std::get<1>(res)));
             value = std::get<2>(res);
             return true;
         case IteratorResultCode::OPTION:
             arg = std::make_unique<OptionView>(
-                    static_cast<const OptionData*>(std::get<1>(res)));
+                    std::get<const OptionData*>(std::get<1>(res)));
             value = std::get<2>(res);
             return true;
         case IteratorResultCode::UNKNOWN:
@@ -1241,7 +1249,7 @@ namespace argos
         if (m_state == State::ERROR)
             ARGOS_THROW("next() called after error.");
         if (m_state == State::DONE)
-            return {IteratorResultCode::DONE, nullptr, {}};
+            return {IteratorResultCode::DONE, {}, {}};
 
         const auto arg = m_state == State::ARGUMENTS_AND_OPTIONS
                              ? m_iterator->next()
@@ -1249,9 +1257,9 @@ namespace argos
         if (!arg)
         {
             if (check_argument_and_option_counts())
-                return {IteratorResultCode::DONE, nullptr, {}};
+                return {IteratorResultCode::DONE, {}, {}};
             else
-                return {IteratorResultCode::ERROR, nullptr, {}};
+                return {IteratorResultCode::ERROR, {}, {}};
         }
 
         if (m_state == State::ARGUMENTS_AND_OPTIONS
@@ -1377,7 +1385,7 @@ namespace argos
                 return {IteratorResultCode::ERROR, option, {}};
             case OptionResult::LAST_ARGUMENT:
                 if (!check_argument_and_option_counts())
-                    return {IteratorResultCode::ERROR, nullptr, {}};
+                    return {IteratorResultCode::ERROR, {}, {}};
                 [[fallthrough]];
             case OptionResult::STOP:
                 copy_remaining_arguments_to_parser_result();
@@ -1390,13 +1398,13 @@ namespace argos
             || !starts_with(m_iterator->current(), flag))
         {
             error("Unknown option: " + std::string(m_iterator->current()));
-            return {IteratorResultCode::ERROR, nullptr, {}};
+            return {IteratorResultCode::ERROR, {}, {}};
         }
         else
         {
             m_parsed_args->add_unprocessed_argument(
                 std::string(m_iterator->current()));
-            return {IteratorResultCode::UNKNOWN, nullptr, m_iterator->current()};
+            return {IteratorResultCode::UNKNOWN, {}, m_iterator->current()};
         }
     }
 
@@ -1427,9 +1435,9 @@ namespace argos
         else
         {
             error("Too many arguments, starting with \"" + name + "\".");
-            return {IteratorResultCode::ERROR, nullptr, {}};
+            return {IteratorResultCode::ERROR, {}, {}};
         }
-        return {IteratorResultCode::UNKNOWN, nullptr, m_iterator->current()};
+        return {IteratorResultCode::UNKNOWN, {}, m_iterator->current()};
     }
 
     // ReSharper disable once CppMemberFunctionMayBeConst
@@ -2221,6 +2229,12 @@ namespace argos
         return {std::move(values), m_args, m_value_id};
     }
 
+    ArgumentValues
+    ArgumentValue::split_n(char separator, size_t num_parts) const
+    {
+        return split(separator, num_parts, num_parts);
+    }
+
     void ArgumentValue::error(const std::string& message) const
     {
         if (!m_args)
@@ -2528,6 +2542,12 @@ namespace argos
                 values.emplace_back(part, arg_id);
         }
         return {std::move(values), m_args, m_value_id};
+    }
+
+    ArgumentValues
+    ArgumentValues::split_n(char separator, size_t num_parts) const
+    {
+        return split(separator, num_parts, num_parts);
     }
 
     ArgumentValueIterator ArgumentValues::begin() const
@@ -3690,165 +3710,6 @@ namespace argos
 
 //****************************************************************************
 // Copyright © 2020 Jan Erik Breimo. All rights reserved.
-// Created by Jan Erik Breimo on 2020-02-13.
-//
-// This file is distributed under the BSD License.
-// License text is included with the source distribution.
-//****************************************************************************
-
-#include <cstdlib>
-
-namespace argos
-{
-    namespace
-    {
-        template <typename T>
-        T str_to_int(const char* str, char** endp, int base);
-
-        template <>
-        long str_to_int<long>(const char* str, char** endp, int base)
-        {
-            return strtol(str, endp, base);
-        }
-
-        template <>
-        long long str_to_int<long long>(const char* str, char** endp, int base)
-        {
-            return strtoll(str, endp, base);
-        }
-
-        template <>
-        unsigned long
-        str_to_int<unsigned long>(const char* str, char** endp, int base)
-        {
-            return strtoul(str, endp, base);
-        }
-
-        template <>
-        unsigned long long
-        str_to_int<unsigned long long>(const char* str, char** endp, int base)
-        {
-            return strtoull(str, endp, base);
-        }
-
-        template <typename T>
-        std::optional<T> parse_integer_impl(const std::string& str, int base)
-        {
-            if (str.empty())
-                return {};
-            char* endp = nullptr;
-            errno = 0;
-            auto value = str_to_int<T>(str.c_str(), &endp, base);
-            if (endp == str.c_str() + str.size() && errno == 0)
-                return value;
-            return {};
-        }
-    }
-
-    template <>
-    std::optional<int> parse_integer<int>(const std::string& str, int base)
-    {
-        const auto n = parse_integer_impl<long>(str, base);
-        if (!n)
-            return {};
-
-        if constexpr (sizeof(int) != sizeof(long))
-        {
-            if (*n < INT_MIN || INT_MAX < *n)
-                return {};
-        }
-        return static_cast<int>(*n);
-    }
-
-    template <>
-    std::optional<unsigned>
-    parse_integer<unsigned>(const std::string& str, int base)
-    {
-        auto n = parse_integer_impl<unsigned long>(str, base);
-        if (!n)
-            return {};
-
-        if constexpr (sizeof(unsigned) != sizeof(unsigned long))
-        {
-            if (UINT_MAX < *n)
-                return {};
-        }
-        return static_cast<unsigned>(*n);
-    }
-
-    template <>
-    std::optional<long> parse_integer<long>(const std::string& str, int base)
-    {
-        return parse_integer_impl<long>(str, base);
-    }
-
-    template <>
-    std::optional<long long>
-    parse_integer<long long>(const std::string& str, int base)
-    {
-        return parse_integer_impl<long long>(str, base);
-    }
-
-    template <>
-    std::optional<unsigned long>
-    parse_integer<unsigned long>(const std::string& str, int base)
-    {
-        return parse_integer_impl<unsigned long>(str, base);
-    }
-
-    template <>
-    std::optional<unsigned long long>
-    parse_integer<unsigned long long>(const std::string& str, int base)
-    {
-        return parse_integer_impl<unsigned long long>(str, base);
-    }
-
-    namespace
-    {
-        template <typename T>
-        T str_to_float(const char* str, char** endp);
-
-        template <>
-        float str_to_float<float>(const char* str, char** endp)
-        {
-            return strtof(str, endp);
-        }
-
-        template <>
-        double str_to_float<double>(const char* str, char** endp)
-        {
-            return strtod(str, endp);
-        }
-
-        template <typename T>
-        std::optional<T> parse_floating_point_impl(const std::string& str)
-        {
-            if (str.empty())
-                return {};
-            char* endp = nullptr;
-            errno = 0;
-            auto value = str_to_float<T>(str.c_str(), &endp);
-            if (endp == str.c_str() + str.size() && errno == 0)
-                return value;
-            return {};
-        }
-    }
-
-    template <>
-    std::optional<float> parse_floating_point<float>(const std::string& str)
-    {
-        return parse_floating_point_impl<float>(str);
-    }
-
-    template <>
-    std::optional<double> parse_floating_point<double>(const std::string& str)
-    {
-        return parse_floating_point_impl<double>(str);
-    }
-}
-
-//****************************************************************************
-// Copyright © 2020 Jan Erik Breimo. All rights reserved.
 // Created by Jan Erik Breimo on 2020-01-26.
 //
 // This file is distributed under the BSD License.
@@ -4397,6 +4258,165 @@ namespace argos
             exit(m_data->parser_settings.error_exit_code);
         else
             ARGOS_THROW("Error while parsing arguments.");
+    }
+}
+
+//****************************************************************************
+// Copyright © 2020 Jan Erik Breimo. All rights reserved.
+// Created by Jan Erik Breimo on 2020-02-13.
+//
+// This file is distributed under the BSD License.
+// License text is included with the source distribution.
+//****************************************************************************
+
+#include <cstdlib>
+
+namespace argos
+{
+    namespace
+    {
+        template <typename T>
+        T str_to_int(const char* str, char** endp, int base);
+
+        template <>
+        long str_to_int<long>(const char* str, char** endp, int base)
+        {
+            return strtol(str, endp, base);
+        }
+
+        template <>
+        long long str_to_int<long long>(const char* str, char** endp, int base)
+        {
+            return strtoll(str, endp, base);
+        }
+
+        template <>
+        unsigned long
+        str_to_int<unsigned long>(const char* str, char** endp, int base)
+        {
+            return strtoul(str, endp, base);
+        }
+
+        template <>
+        unsigned long long
+        str_to_int<unsigned long long>(const char* str, char** endp, int base)
+        {
+            return strtoull(str, endp, base);
+        }
+
+        template <typename T>
+        std::optional<T> parse_integer_impl(const std::string& str, int base)
+        {
+            if (str.empty())
+                return {};
+            char* endp = nullptr;
+            errno = 0;
+            auto value = str_to_int<T>(str.c_str(), &endp, base);
+            if (endp == str.c_str() + str.size() && errno == 0)
+                return value;
+            return {};
+        }
+    }
+
+    template <>
+    std::optional<int> parse_integer<int>(const std::string& str, int base)
+    {
+        const auto n = parse_integer_impl<long>(str, base);
+        if (!n)
+            return {};
+
+        if constexpr (sizeof(int) != sizeof(long))
+        {
+            if (*n < INT_MIN || INT_MAX < *n)
+                return {};
+        }
+        return static_cast<int>(*n);
+    }
+
+    template <>
+    std::optional<unsigned>
+    parse_integer<unsigned>(const std::string& str, int base)
+    {
+        auto n = parse_integer_impl<unsigned long>(str, base);
+        if (!n)
+            return {};
+
+        if constexpr (sizeof(unsigned) != sizeof(unsigned long))
+        {
+            if (UINT_MAX < *n)
+                return {};
+        }
+        return static_cast<unsigned>(*n);
+    }
+
+    template <>
+    std::optional<long> parse_integer<long>(const std::string& str, int base)
+    {
+        return parse_integer_impl<long>(str, base);
+    }
+
+    template <>
+    std::optional<long long>
+    parse_integer<long long>(const std::string& str, int base)
+    {
+        return parse_integer_impl<long long>(str, base);
+    }
+
+    template <>
+    std::optional<unsigned long>
+    parse_integer<unsigned long>(const std::string& str, int base)
+    {
+        return parse_integer_impl<unsigned long>(str, base);
+    }
+
+    template <>
+    std::optional<unsigned long long>
+    parse_integer<unsigned long long>(const std::string& str, int base)
+    {
+        return parse_integer_impl<unsigned long long>(str, base);
+    }
+
+    namespace
+    {
+        template <typename T>
+        T str_to_float(const char* str, char** endp);
+
+        template <>
+        float str_to_float<float>(const char* str, char** endp)
+        {
+            return strtof(str, endp);
+        }
+
+        template <>
+        double str_to_float<double>(const char* str, char** endp)
+        {
+            return strtod(str, endp);
+        }
+
+        template <typename T>
+        std::optional<T> parse_floating_point_impl(const std::string& str)
+        {
+            if (str.empty())
+                return {};
+            char* endp = nullptr;
+            errno = 0;
+            auto value = str_to_float<T>(str.c_str(), &endp);
+            if (endp == str.c_str() + str.size() && errno == 0)
+                return value;
+            return {};
+        }
+    }
+
+    template <>
+    std::optional<float> parse_floating_point<float>(const std::string& str)
+    {
+        return parse_floating_point_impl<float>(str);
+    }
+
+    template <>
+    std::optional<double> parse_floating_point<double>(const std::string& str)
+    {
+        return parse_floating_point_impl<double>(str);
     }
 }
 

--- a/single_src/Argos/Argos.hpp
+++ b/single_src/Argos/Argos.hpp
@@ -896,7 +896,7 @@ namespace argos
 
         /**
          * @brief Splits the string from the command line on @a separator and
-         *      returns the resulting parts.
+         *  returns the resulting parts.
          *
          * An error message is displayed if the result has less than
          * @a min_parts parts (i.e. number of separators is less than
@@ -908,10 +908,28 @@ namespace argos
          * limit to the number of parts.
          *
          * @throw ArgosException if @a auto_exit is false and the result
-         *      has less than @a min_parts parts.
+         *  has less than @a min_parts parts.
          */
         [[nodiscard]] ArgumentValues
         split(char separator, size_t min_parts = 0, size_t max_parts = 0) const;
+
+        /**
+         * @brief Splits the string from the command line on @a separator into
+         *  exactly @a num_parts parts and returns them.
+         *
+         * An error message is displayed if the result has less than
+         * @a num_parts parts (i.e. number of separators is less than
+         * num_parts - 1). If there are more occurrences of @a separator, they
+         * will be included in the last part.
+         *
+         * @note This function is equivalent to calling
+         *  `split(separator, num_parts, num_parts)`.
+         *
+         * @throw ArgosException if @a auto_exit is false and the result
+         *  has less than @a min_parts parts.
+         */
+        [[nodiscard]] ArgumentValues
+        split_n(char separator, size_t num_parts) const;
 
         /**
          * Display @a message as if it was an error produced within Argos
@@ -1307,6 +1325,22 @@ namespace argos
          */
         [[nodiscard]] ArgumentValues
         split(char separator, size_t min_parts = 0, size_t max_parts = 0) const;
+
+        /**
+         * @brief Splits each value on @a separator into exactly @a num_parts
+         *  parts and returns the result.
+         *
+         * @note This function is equivalent to calling
+         *  `split(separator, num_parts, num_parts)`.
+         *
+         * @param separator The separator.
+         * @param num_parts The number of parts each value must
+         *  consist of.
+         * @throw ArgosException if any value consists of less than
+         *  @a num_parts parts.
+         */
+        [[nodiscard]] ArgumentValues
+        split_n(char separator, size_t num_parts) const;
 
         /**
          * @brief Returns an iterator pointing to the first value.

--- a/src/Argos/ArgumentValue.cpp
+++ b/src/Argos/ArgumentValue.cpp
@@ -163,6 +163,12 @@ namespace argos
         return {std::move(values), m_args, m_value_id};
     }
 
+    ArgumentValues
+    ArgumentValue::split_n(char separator, size_t num_parts) const
+    {
+        return split(separator, num_parts, num_parts);
+    }
+
     void ArgumentValue::error(const std::string& message) const
     {
         if (!m_args)

--- a/src/Argos/ArgumentValues.cpp
+++ b/src/Argos/ArgumentValues.cpp
@@ -242,6 +242,12 @@ namespace argos
         return {std::move(values), m_args, m_value_id};
     }
 
+    ArgumentValues
+    ArgumentValues::split_n(char separator, size_t num_parts) const
+    {
+        return split(separator, num_parts, num_parts);
+    }
+
     ArgumentValueIterator ArgumentValues::begin() const
     {
         return {m_values.begin(), m_args, m_value_id};

--- a/tests/ArgosTest/test_ArgumentValue.cpp
+++ b/tests/ArgosTest/test_ArgumentValue.cpp
@@ -17,8 +17,12 @@ TEST_CASE("Test ArgumentValue split")
         .auto_exit(false)
         .add(Option({"--f="}).argument("M,N"))
         .parse({"--f=34,45"});
-    auto values = args.value("--f=").split(',', 2, 2).as_ints();
-    REQUIRE(values == std::vector<int>{34, 45});
+
+    auto values1 = args.value("--f=").split(',', 2, 2).as_ints();
+    REQUIRE(values1 == std::vector<int>{34, 45});
+
+    auto values2 = args.value("--f=").split_n(',', 2).as_ints();
+    REQUIRE(values2 == std::vector<int>{34, 45});
 }
 
 TEST_CASE("Test ArgumentValues split")


### PR DESCRIPTION
I've found it is a fairly common use case to want to split arguments into an exact number of parts, typically two, and it irks me to have to repeat the same argument twice in calls to split.