### PR TITLE
Disallow mixing arguments and commands

### DIFF
--- a/include/Argos/ArgumentParser.hpp
+++ b/include/Argos/ArgumentParser.hpp
@@ -74,13 +74,17 @@ namespace argos
         /**
          * @brief Add a new argument definition to the ArgumentParser.
          *
-         * @throw ArgosException if @a argument has been moved-from or
-         *  doesn't have a name.
+         * @note The program cannot have both arguments and sub-commands.
+         *
+         * @throw ArgosException if @a argument has been moved-from,
+         *  doesn't have a name, or sub-commands have already been added.
          */
         ArgumentParser& add(Argument& argument);
 
         /**
          * @brief Add a new argument definition to the ArgumentParser.
+         *
+         * @note The program cannot have both arguments and sub-commands.
          *
          * @throw ArgosException if @a argument has been moved-from or
          *  doesn't have a name.
@@ -106,24 +110,32 @@ namespace argos
         /**
          * @brief Add a new sub-command definition to the ArgumentParser.
          *
-         * @throw ArgosException if @a command has been moved-from or
-         *  doesn't have a name.
+         * @note The program cannot have both arguments and sub-commands.
+         *
+         * @throw ArgosException if @a command has been moved-from,
+         *  doesn't have a name, or arguments have already been added.
          */
         ArgumentParser& add(Command& command);
 
         /**
          * @brief Add a new sub-command definition to the ArgumentParser.
+        *
+         * @note The program cannot have both arguments and sub-commands.
          *
-         * @throw ArgosException if @a command has been moved-from or
-         *  doesn't have a name.
+         * @throw ArgosException if @a command has been moved-from,
+         *  doesn't have a name, or arguments have already been added.
          */
         ArgumentParser& add(Command&& command);
 
         /**
-         * @brief Copy arguments, options and sub-commands from @a command
-         *  to this ArgumentParser.
+        * @brief Add copies of all arguments, options and sub-commands in
+         *  @a command.
          *
-         * All other settings are left unchanged.
+         * Any texts (help, about, etc.) set in @a command will be copied
+         * as well.
+         *
+         * @throw ArgosException if the parser already has any of the texts
+         *  in @a command.
          */
         ArgumentParser& copy_from(const Command& command);
 

--- a/include/Argos/Command.hpp
+++ b/include/Argos/Command.hpp
@@ -73,6 +73,11 @@ namespace argos
          * @a argument will be moved from, and can not be used
          * afterwards. To avoid this, create a copy of @a argument and
          * add that to the command instead.
+         *
+         * @note A command cannot have both arguments and sub-commands.
+         *
+         * @throw ArgosException if @a argument has been moved-from,
+         *  doesn't have a name, or sub-commands have already been added.
          */
         Command& add(Argument& argument);
 
@@ -80,6 +85,11 @@ namespace argos
          * @brief Adds an argument to the command.
          *
          * @a argument will be moved from, and can not be used afterwards.
+         *
+         * @note A command cannot have both arguments and sub-commands.
+         *
+         * @throw ArgosException if @a argument has been moved-from,
+         *  doesn't have a name, or sub-commands have already been added.
          */
         Command& add(Argument&& argument);
 
@@ -87,9 +97,8 @@ namespace argos
          * @brief Adds an option to the command.
          *
          * @a option will be moved from, and can not be used afterwards.
-         *
-         * To avoid this, create a copy of @a option and
-         * add that to the command instead.
+         * To avoid this, create a copy of @a option and add that to the
+         * command instead.
          */
         Command& add(Option& option);
 
@@ -104,6 +113,11 @@ namespace argos
          * @brief Adds a sub-command to the command.
          *
          * @a command will be moved from, and can not be used afterwards.
+         *
+         * @note A command cannot have both arguments and sub-commands.
+         *
+         * @throw ArgosException if @a command has been moved-from,
+         *  doesn't have a name, or arguments have already been added.
          */
         Command& add(Command& command);
 
@@ -111,6 +125,11 @@ namespace argos
          * @brief Adds a sub-command to the command.
          *
          * @a command will be moved from, and can not be used afterwards.
+         *
+         * @note A command cannot have both arguments and sub-commands.
+         *
+         * @throw ArgosException if @a command has been moved-from,
+         *  doesn't have a name, or arguments have already been added.
          */
         Command& add(Command&& command);
 

--- a/single_src/Argos/Argos.cpp
+++ b/single_src/Argos/Argos.cpp
@@ -3025,6 +3025,8 @@ namespace argos
     {
         if (!arg)
             ARGOS_THROW("Argument is empty (it has probably already been added).");
+        if (!commands.empty())
+            ARGOS_THROW("A command cannot have both arguments and subcommands.");
         if (arg->name.empty())
             ARGOS_THROW("Argument must have a name.");
         if (arg->section.empty())
@@ -3047,6 +3049,8 @@ namespace argos
     {
         if (!cmd)
             ARGOS_THROW("Command is empty (it has probably already been added).");
+        if (!arguments.empty())
+            ARGOS_THROW("A command cannot have both arguments and subcommands.");
         if (cmd->name.empty())
             ARGOS_THROW("Command must have a name.");
         if (cmd->section.empty())
@@ -3180,8 +3184,7 @@ namespace argos
 
             if (!cmd.require_subcommand)
             {
-                cmd.require_subcommand = !cmd.commands.empty()
-                                      && cmd.arguments.empty();
+                cmd.require_subcommand = !cmd.commands.empty();
             }
         }
 
@@ -4537,6 +4540,165 @@ namespace argos
 
 //****************************************************************************
 // Copyright © 2020 Jan Erik Breimo. All rights reserved.
+// Created by Jan Erik Breimo on 2020-02-13.
+//
+// This file is distributed under the Zero-Clause BSD License.
+// License text is included with the source distribution.
+//****************************************************************************
+
+#include <cstdlib>
+
+namespace argos
+{
+    namespace
+    {
+        template <typename T>
+        T str_to_int(const char* str, char** endp, int base);
+
+        template <>
+        long str_to_int<long>(const char* str, char** endp, int base)
+        {
+            return strtol(str, endp, base);
+        }
+
+        template <>
+        long long str_to_int<long long>(const char* str, char** endp, int base)
+        {
+            return strtoll(str, endp, base);
+        }
+
+        template <>
+        unsigned long
+        str_to_int<unsigned long>(const char* str, char** endp, int base)
+        {
+            return strtoul(str, endp, base);
+        }
+
+        template <>
+        unsigned long long
+        str_to_int<unsigned long long>(const char* str, char** endp, int base)
+        {
+            return strtoull(str, endp, base);
+        }
+
+        template <typename T>
+        std::optional<T> parse_integer_impl(const std::string& str, int base)
+        {
+            if (str.empty())
+                return {};
+            char* endp = nullptr;
+            errno = 0;
+            auto value = str_to_int<T>(str.c_str(), &endp, base);
+            if (endp == str.c_str() + str.size() && errno == 0)
+                return value;
+            return {};
+        }
+    }
+
+    template <>
+    std::optional<int> parse_integer<int>(const std::string& str, int base)
+    {
+        const auto n = parse_integer_impl<long>(str, base);
+        if (!n)
+            return {};
+
+        if constexpr (sizeof(int) != sizeof(long))
+        {
+            if (*n < INT_MIN || INT_MAX < *n)
+                return {};
+        }
+        return static_cast<int>(*n);
+    }
+
+    template <>
+    std::optional<unsigned>
+    parse_integer<unsigned>(const std::string& str, int base)
+    {
+        auto n = parse_integer_impl<unsigned long>(str, base);
+        if (!n)
+            return {};
+
+        if constexpr (sizeof(unsigned) != sizeof(unsigned long))
+        {
+            if (UINT_MAX < *n)
+                return {};
+        }
+        return static_cast<unsigned>(*n);
+    }
+
+    template <>
+    std::optional<long> parse_integer<long>(const std::string& str, int base)
+    {
+        return parse_integer_impl<long>(str, base);
+    }
+
+    template <>
+    std::optional<long long>
+    parse_integer<long long>(const std::string& str, int base)
+    {
+        return parse_integer_impl<long long>(str, base);
+    }
+
+    template <>
+    std::optional<unsigned long>
+    parse_integer<unsigned long>(const std::string& str, int base)
+    {
+        return parse_integer_impl<unsigned long>(str, base);
+    }
+
+    template <>
+    std::optional<unsigned long long>
+    parse_integer<unsigned long long>(const std::string& str, int base)
+    {
+        return parse_integer_impl<unsigned long long>(str, base);
+    }
+
+    namespace
+    {
+        template <typename T>
+        T str_to_float(const char* str, char** endp);
+
+        template <>
+        float str_to_float<float>(const char* str, char** endp)
+        {
+            return strtof(str, endp);
+        }
+
+        template <>
+        double str_to_float<double>(const char* str, char** endp)
+        {
+            return strtod(str, endp);
+        }
+
+        template <typename T>
+        std::optional<T> parse_floating_point_impl(const std::string& str)
+        {
+            if (str.empty())
+                return {};
+            char* endp = nullptr;
+            errno = 0;
+            auto value = str_to_float<T>(str.c_str(), &endp);
+            if (endp == str.c_str() + str.size() && errno == 0)
+                return value;
+            return {};
+        }
+    }
+
+    template <>
+    std::optional<float> parse_floating_point<float>(const std::string& str)
+    {
+        return parse_floating_point_impl<float>(str);
+    }
+
+    template <>
+    std::optional<double> parse_floating_point<double>(const std::string& str)
+    {
+        return parse_floating_point_impl<double>(str);
+    }
+}
+
+//****************************************************************************
+// Copyright © 2020 Jan Erik Breimo. All rights reserved.
 // Created by Jan Erik Breimo on 2020-01-26.
 //
 // This file is distributed under the Zero-Clause BSD License.
@@ -5193,165 +5355,6 @@ namespace argos
     {
         add_version_option(data);
         finish_initialization(data.command, data);
-    }
-}
-
-//****************************************************************************
-// Copyright © 2020 Jan Erik Breimo. All rights reserved.
-// Created by Jan Erik Breimo on 2020-02-13.
-//
-// This file is distributed under the Zero-Clause BSD License.
-// License text is included with the source distribution.
-//****************************************************************************
-
-#include <cstdlib>
-
-namespace argos
-{
-    namespace
-    {
-        template <typename T>
-        T str_to_int(const char* str, char** endp, int base);
-
-        template <>
-        long str_to_int<long>(const char* str, char** endp, int base)
-        {
-            return strtol(str, endp, base);
-        }
-
-        template <>
-        long long str_to_int<long long>(const char* str, char** endp, int base)
-        {
-            return strtoll(str, endp, base);
-        }
-
-        template <>
-        unsigned long
-        str_to_int<unsigned long>(const char* str, char** endp, int base)
-        {
-            return strtoul(str, endp, base);
-        }
-
-        template <>
-        unsigned long long
-        str_to_int<unsigned long long>(const char* str, char** endp, int base)
-        {
-            return strtoull(str, endp, base);
-        }
-
-        template <typename T>
-        std::optional<T> parse_integer_impl(const std::string& str, int base)
-        {
-            if (str.empty())
-                return {};
-            char* endp = nullptr;
-            errno = 0;
-            auto value = str_to_int<T>(str.c_str(), &endp, base);
-            if (endp == str.c_str() + str.size() && errno == 0)
-                return value;
-            return {};
-        }
-    }
-
-    template <>
-    std::optional<int> parse_integer<int>(const std::string& str, int base)
-    {
-        const auto n = parse_integer_impl<long>(str, base);
-        if (!n)
-            return {};
-
-        if constexpr (sizeof(int) != sizeof(long))
-        {
-            if (*n < INT_MIN || INT_MAX < *n)
-                return {};
-        }
-        return static_cast<int>(*n);
-    }
-
-    template <>
-    std::optional<unsigned>
-    parse_integer<unsigned>(const std::string& str, int base)
-    {
-        auto n = parse_integer_impl<unsigned long>(str, base);
-        if (!n)
-            return {};
-
-        if constexpr (sizeof(unsigned) != sizeof(unsigned long))
-        {
-            if (UINT_MAX < *n)
-                return {};
-        }
-        return static_cast<unsigned>(*n);
-    }
-
-    template <>
-    std::optional<long> parse_integer<long>(const std::string& str, int base)
-    {
-        return parse_integer_impl<long>(str, base);
-    }
-
-    template <>
-    std::optional<long long>
-    parse_integer<long long>(const std::string& str, int base)
-    {
-        return parse_integer_impl<long long>(str, base);
-    }
-
-    template <>
-    std::optional<unsigned long>
-    parse_integer<unsigned long>(const std::string& str, int base)
-    {
-        return parse_integer_impl<unsigned long>(str, base);
-    }
-
-    template <>
-    std::optional<unsigned long long>
-    parse_integer<unsigned long long>(const std::string& str, int base)
-    {
-        return parse_integer_impl<unsigned long long>(str, base);
-    }
-
-    namespace
-    {
-        template <typename T>
-        T str_to_float(const char* str, char** endp);
-
-        template <>
-        float str_to_float<float>(const char* str, char** endp)
-        {
-            return strtof(str, endp);
-        }
-
-        template <>
-        double str_to_float<double>(const char* str, char** endp)
-        {
-            return strtod(str, endp);
-        }
-
-        template <typename T>
-        std::optional<T> parse_floating_point_impl(const std::string& str)
-        {
-            if (str.empty())
-                return {};
-            char* endp = nullptr;
-            errno = 0;
-            auto value = str_to_float<T>(str.c_str(), &endp);
-            if (endp == str.c_str() + str.size() && errno == 0)
-                return value;
-            return {};
-        }
-    }
-
-    template <>
-    std::optional<float> parse_floating_point<float>(const std::string& str)
-    {
-        return parse_floating_point_impl<float>(str);
-    }
-
-    template <>
-    std::optional<double> parse_floating_point<double>(const std::string& str)
-    {
-        return parse_floating_point_impl<double>(str);
     }
 }
 

--- a/single_src/Argos/Argos.cpp
+++ b/single_src/Argos/Argos.cpp
@@ -1321,17 +1321,19 @@ namespace argos
         {
             return process_option(*arg);
         }
+        else if (m_command->commands.empty())
+        {
+            return process_argument(*arg);
+        }
+        else if (auto cmd = m_command->find_command(
+                *arg, m_data->parser_settings.case_insensitive))
+        {
+            return process_command(cmd);
+        }
         else
         {
-            if (m_argument_counter.is_complete())
-            {
-                if (auto cmd = m_command->find_command(
-                    *arg, m_data->parser_settings.case_insensitive))
-                {
-                    return process_command(cmd);
-                }
-            }
-            return process_argument(*arg);
+            error("Unknown command: " + std::string(*arg));
+            return {IteratorResultCode::ERROR, {}, {}};
         }
     }
 

--- a/single_src/Argos/Argos.hpp
+++ b/single_src/Argos/Argos.hpp
@@ -2705,6 +2705,11 @@ namespace argos
          * @a argument will be moved from, and can not be used
          * afterwards. To avoid this, create a copy of @a argument and
          * add that to the command instead.
+         *
+         * @note A command cannot have both arguments and sub-commands.
+         *
+         * @throw ArgosException if @a argument has been moved-from,
+         *  doesn't have a name, or sub-commands have already been added.
          */
         Command& add(Argument& argument);
 
@@ -2712,6 +2717,11 @@ namespace argos
          * @brief Adds an argument to the command.
          *
          * @a argument will be moved from, and can not be used afterwards.
+         *
+         * @note A command cannot have both arguments and sub-commands.
+         *
+         * @throw ArgosException if @a argument has been moved-from,
+         *  doesn't have a name, or sub-commands have already been added.
          */
         Command& add(Argument&& argument);
 
@@ -2719,9 +2729,8 @@ namespace argos
          * @brief Adds an option to the command.
          *
          * @a option will be moved from, and can not be used afterwards.
-         *
-         * To avoid this, create a copy of @a option and
-         * add that to the command instead.
+         * To avoid this, create a copy of @a option and add that to the
+         * command instead.
          */
         Command& add(Option& option);
 
@@ -2736,6 +2745,11 @@ namespace argos
          * @brief Adds a sub-command to the command.
          *
          * @a command will be moved from, and can not be used afterwards.
+         *
+         * @note A command cannot have both arguments and sub-commands.
+         *
+         * @throw ArgosException if @a command has been moved-from,
+         *  doesn't have a name, or arguments have already been added.
          */
         Command& add(Command& command);
 
@@ -2743,6 +2757,11 @@ namespace argos
          * @brief Adds a sub-command to the command.
          *
          * @a command will be moved from, and can not be used afterwards.
+         *
+         * @note A command cannot have both arguments and sub-commands.
+         *
+         * @throw ArgosException if @a command has been moved-from,
+         *  doesn't have a name, or arguments have already been added.
          */
         Command& add(Command&& command);
 
@@ -2883,6 +2902,11 @@ namespace argos
 
         std::unique_ptr<CommandData> data_;
     };
+
+    /**
+     * @brief A convenient short alias for Command.
+     */
+    using Cmd = Command;
 }
 
 //****************************************************************************
@@ -2956,13 +2980,17 @@ namespace argos
         /**
          * @brief Add a new argument definition to the ArgumentParser.
          *
-         * @throw ArgosException if @a argument has been moved-from or
-         *  doesn't have a name.
+         * @note The program cannot have both arguments and sub-commands.
+         *
+         * @throw ArgosException if @a argument has been moved-from,
+         *  doesn't have a name, or sub-commands have already been added.
          */
         ArgumentParser& add(Argument& argument);
 
         /**
          * @brief Add a new argument definition to the ArgumentParser.
+         *
+         * @note The program cannot have both arguments and sub-commands.
          *
          * @throw ArgosException if @a argument has been moved-from or
          *  doesn't have a name.
@@ -2988,24 +3016,32 @@ namespace argos
         /**
          * @brief Add a new sub-command definition to the ArgumentParser.
          *
-         * @throw ArgosException if @a command has been moved-from or
-         *  doesn't have a name.
+         * @note The program cannot have both arguments and sub-commands.
+         *
+         * @throw ArgosException if @a command has been moved-from,
+         *  doesn't have a name, or arguments have already been added.
          */
         ArgumentParser& add(Command& command);
 
         /**
          * @brief Add a new sub-command definition to the ArgumentParser.
+        *
+         * @note The program cannot have both arguments and sub-commands.
          *
-         * @throw ArgosException if @a command has been moved-from or
-         *  doesn't have a name.
+         * @throw ArgosException if @a command has been moved-from,
+         *  doesn't have a name, or arguments have already been added.
          */
         ArgumentParser& add(Command&& command);
 
         /**
-         * @brief Copy arguments, options and sub-commands from @a command
-         *  to this ArgumentParser.
+        * @brief Add copies of all arguments, options and sub-commands in
+         *  @a command.
          *
-         * All other settings are left unchanged.
+         * Any texts (help, about, etc.) set in @a command will be copied
+         * as well.
+         *
+         * @throw ArgosException if the parser already has any of the texts
+         *  in @a command.
          */
         ArgumentParser& copy_from(const Command& command);
 

--- a/src/Argos/ArgumentIteratorImpl.cpp
+++ b/src/Argos/ArgumentIteratorImpl.cpp
@@ -113,17 +113,19 @@ namespace argos
         {
             return process_option(*arg);
         }
+        else if (m_command->commands.empty())
+        {
+            return process_argument(*arg);
+        }
+        else if (auto cmd = m_command->find_command(
+                *arg, m_data->parser_settings.case_insensitive))
+        {
+            return process_command(cmd);
+        }
         else
         {
-            if (m_argument_counter.is_complete())
-            {
-                if (auto cmd = m_command->find_command(
-                    *arg, m_data->parser_settings.case_insensitive))
-                {
-                    return process_command(cmd);
-                }
-            }
-            return process_argument(*arg);
+            error("Unknown command: " + std::string(*arg));
+            return {IteratorResultCode::ERROR, {}, {}};
         }
     }
 

--- a/src/Argos/CommandData.cpp
+++ b/src/Argos/CommandData.cpp
@@ -115,6 +115,8 @@ namespace argos
     {
         if (!arg)
             ARGOS_THROW("Argument is empty (it has probably already been added).");
+        if (!commands.empty())
+            ARGOS_THROW("A command cannot have both arguments and subcommands.");
         if (arg->name.empty())
             ARGOS_THROW("Argument must have a name.");
         if (arg->section.empty())
@@ -137,6 +139,8 @@ namespace argos
     {
         if (!cmd)
             ARGOS_THROW("Command is empty (it has probably already been added).");
+        if (!arguments.empty())
+            ARGOS_THROW("A command cannot have both arguments and subcommands.");
         if (cmd->name.empty())
             ARGOS_THROW("Command must have a name.");
         if (cmd->section.empty())
@@ -270,8 +274,7 @@ namespace argos
 
             if (!cmd.require_subcommand)
             {
-                cmd.require_subcommand = !cmd.commands.empty()
-                                      && cmd.arguments.empty();
+                cmd.require_subcommand = !cmd.commands.empty();
             }
         }
 

--- a/tests/ArgosTest/test_Subcommands.cpp
+++ b/tests/ArgosTest/test_Subcommands.cpp
@@ -204,3 +204,19 @@ TEST_CASE("Final argument option and multi-commands")
     REQUIRE(cmd.values("NAME")[0].as_string() == "name2");
     REQUIRE(cmd.value("--baz").as_string() == "qux");
 }
+
+TEST_CASE("Cannot mix arguments and subcommands")
+{
+    using namespace argos;
+    Command cmd;
+    SECTION("Command after argument")
+    {
+        cmd.add(Arg("arg"));
+        REQUIRE_THROWS_AS(cmd.add(Command("foo")), ArgosException);
+    }
+    SECTION("Argument after command")
+    {
+        cmd.add(Command("foo"));
+        REQUIRE_THROWS_AS(cmd.add(Arg("arg")), ArgosException);
+    }
+}


### PR DESCRIPTION
Make it illegal to mix arguments and sub-commands. Allowing a command to have both makes it too tricky to handle the help options of sub-commands, among other things.