### PR TITLE
Fix a problem with Command's section

### DIFF
--- a/include/Argos/Command.hpp
+++ b/include/Argos/Command.hpp
@@ -160,6 +160,18 @@ namespace argos
         Command& about(std::string text);
 
         /**
+         * @brief Sets the heading that the command will be listed under in
+         *      the parent command's help text.
+         *
+         * The default heading for commands is "COMMANDS".
+         * @param name All arguments, options and commands that share the same
+         *      section name will be listed under the same heading.
+         * @return Reference to itself. This makes it possible to chain
+         *      method calls.
+         */
+        Command& section(std::string name);
+
+        /**
          * @brief Sets a section (or heading) that is automatically assigned
          *   to arguments, sub-commands and options when they are added.
          *
@@ -172,7 +184,7 @@ namespace argos
          * @param name All arguments, sub-commands and options with the same
          *  section name will be listed under the same heading.
          */
-        Command& section(const std::string& name);
+        Command& current_section(std::string name);
 
         /**
          * @brief Set the given part of the help text.

--- a/single_src/Argos/Argos.cpp
+++ b/single_src/Argos/Argos.cpp
@@ -2843,10 +2843,17 @@ namespace argos
         return *this;
     }
 
-    Command& Command::section(const std::string& name)
+    Command& Command::section(std::string name)
     {
         check_command();
-        data_->current_section = name;
+        data_->section = std::move(name);
+        return *this;
+    }
+
+    Command& Command::current_section(std::string name)
+    {
+        check_command();
+        data_->current_section = std::move(name);
         return *this;
     }
 
@@ -4923,6 +4930,12 @@ namespace argos
             stream << "Unprocessed arguments:";
             for (auto& arg : parsed_args.unprocessed_arguments())
                 stream << " \"" << arg << "\"";
+        }
+
+        for (const auto& subcommand : parsed_args.subcommands())
+        {
+            stream << "\nSubcommand: " << subcommand.name() << "\n";
+            print(subcommand, stream);
         }
     }
 }

--- a/single_src/Argos/Argos.hpp
+++ b/single_src/Argos/Argos.hpp
@@ -2792,6 +2792,18 @@ namespace argos
         Command& about(std::string text);
 
         /**
+         * @brief Sets the heading that the command will appear
+         *      under in the help text.
+         *
+         * The default heading for commands is "COMMANDS".
+         * @param name All arguments, options and commands that share the same
+         *      section name will be listed under the same heading.
+         * @return Reference to itself. This makes it possible to chain
+         *      method calls.
+         */
+        Command& section(std::string name);
+
+        /**
          * @brief Sets a section (or heading) that is automatically assigned
          *   to arguments, sub-commands and options when they are added.
          *
@@ -2804,7 +2816,7 @@ namespace argos
          * @param name All arguments, sub-commands and options with the same
          *  section name will be listed under the same heading.
          */
-        Command& section(const std::string& name);
+        Command& current_section(std::string name);
 
         /**
          * @brief Set the given part of the help text.

--- a/src/Argos/Command.cpp
+++ b/src/Argos/Command.cpp
@@ -108,10 +108,17 @@ namespace argos
         return *this;
     }
 
-    Command& Command::section(const std::string& name)
+    Command& Command::section(std::string name)
     {
         check_command();
-        data_->current_section = name;
+        data_->section = std::move(name);
+        return *this;
+    }
+
+    Command& Command::current_section(std::string name)
+    {
+        check_command();
+        data_->current_section = std::move(name);
         return *this;
     }
 

--- a/src/Argos/ParsedArguments.cpp
+++ b/src/Argos/ParsedArguments.cpp
@@ -229,5 +229,11 @@ namespace argos
             for (auto& arg : parsed_args.unprocessed_arguments())
                 stream << " \"" << arg << "\"";
         }
+
+        for (const auto& subcommand : parsed_args.subcommands())
+        {
+            stream << "\nSubcommand: " << subcommand.name() << "\n";
+            print(subcommand, stream);
+        }
     }
 }


### PR DESCRIPTION
- Change the name of Command's section to current_section.
- Add a new section function to Command
  that behaves the same way as section in Argument and Option. 
- Include sub-commands in
  `print(ParsedArguments)`.