### PR TITLE
Fix bug in ParsedArguments

### DIFF
--- a/single_src/Argos/Argos.cpp
+++ b/single_src/Argos/Argos.cpp
@@ -4794,7 +4794,7 @@ namespace argos
     ParsedArguments::all_arguments() const
     {
         std::vector<std::unique_ptr<ArgumentView>> result;
-        for (auto& a : m_impl->parser_data()->command.arguments)
+        for (auto& a : m_impl->command()->arguments)
             result.emplace_back(std::make_unique<ArgumentView>(a.get()));
         return result;
     }
@@ -4803,7 +4803,7 @@ namespace argos
     ParsedArguments::all_options() const
     {
         std::vector<std::unique_ptr<OptionView>> result;
-        for (auto& o : m_impl->parser_data()->command.options)
+        for (auto& o : m_impl->command()->options)
             result.emplace_back(std::make_unique<OptionView>(o.get()));
         return result;
     }
@@ -4812,7 +4812,7 @@ namespace argos
     ParsedArguments::all_subcommands() const
     {
         std::vector<std::unique_ptr<CommandView>> result;
-        for (auto& c : m_impl->parser_data()->command.commands)
+        for (auto& c : m_impl->command()->commands)
             result.emplace_back(std::make_unique<CommandView>(c.get()));
         return result;
     }

--- a/single_src/Argos/Argos.hpp
+++ b/single_src/Argos/Argos.hpp
@@ -2792,8 +2792,8 @@ namespace argos
         Command& about(std::string text);
 
         /**
-         * @brief Sets the heading that the command will appear
-         *      under in the help text.
+         * @brief Sets the heading that the command will be listed under in
+         *      the parent command's help text.
          *
          * The default heading for commands is "COMMANDS".
          * @param name All arguments, options and commands that share the same

--- a/src/Argos/ParsedArguments.cpp
+++ b/src/Argos/ParsedArguments.cpp
@@ -92,7 +92,7 @@ namespace argos
     ParsedArguments::all_arguments() const
     {
         std::vector<std::unique_ptr<ArgumentView>> result;
-        for (auto& a : m_impl->parser_data()->command.arguments)
+        for (auto& a : m_impl->command()->arguments)
             result.emplace_back(std::make_unique<ArgumentView>(a.get()));
         return result;
     }
@@ -101,7 +101,7 @@ namespace argos
     ParsedArguments::all_options() const
     {
         std::vector<std::unique_ptr<OptionView>> result;
-        for (auto& o : m_impl->parser_data()->command.options)
+        for (auto& o : m_impl->command()->options)
             result.emplace_back(std::make_unique<OptionView>(o.get()));
         return result;
     }
@@ -110,7 +110,7 @@ namespace argos
     ParsedArguments::all_subcommands() const
     {
         std::vector<std::unique_ptr<CommandView>> result;
-        for (auto& c : m_impl->parser_data()->command.commands)
+        for (auto& c : m_impl->command()->commands)
             result.emplace_back(std::make_unique<CommandView>(c.get()));
         return result;
     }

--- a/tests/ArgosTest/test_ParsedArguments.cpp
+++ b/tests/ArgosTest/test_ParsedArguments.cpp
@@ -45,3 +45,38 @@ TEST_CASE("Test filter argc/argv")
         REQUIRE(std::string(v[3]) == "text");
     }
 }
+
+TEST_CASE("Check options of arguments of main command and sub-commands")
+{
+    using namespace argos;
+    auto args = ArgumentParser()
+        .add(Opt("-f", "--flag"))
+        .add(Cmd("cmd")
+            .add(Opt("-o", "--option"))
+            .add(Arg("ARG")))
+        .parse({"-f", "cmd", "-o", "arg"});
+    auto all_opts = args.all_options();
+    REQUIRE(all_opts.size() == 2);
+    REQUIRE(all_opts[0]->flags().size() == 2);
+    REQUIRE(all_opts[0]->flags()[0] == "-f");
+    REQUIRE(all_opts[0]->flags()[1] == "--flag");
+    REQUIRE(all_opts[1]->flags().size() == 2);
+    REQUIRE(all_opts[1]->flags()[0] == "-h");;
+    REQUIRE(all_opts[1]->flags()[1] == "--help");
+    REQUIRE(args.all_arguments().empty());
+    auto cmds = args.subcommands();
+    REQUIRE(cmds.size() == 1);
+    auto cmd = cmds[0];
+    REQUIRE(cmd.name() == "cmd");
+    all_opts = cmd.all_options();
+    REQUIRE(all_opts.size() == 2);
+    REQUIRE(all_opts[0]->flags().size() == 2);
+    REQUIRE(all_opts[0]->flags()[0] == "-o");
+    REQUIRE(all_opts[0]->flags()[1] == "--option");
+    REQUIRE(all_opts[1]->flags().size() == 2);
+    REQUIRE(all_opts[1]->flags()[0] == "-h");
+    REQUIRE(all_opts[1]->flags()[1] == "--help");
+    auto all_args = cmd.all_arguments();
+    REQUIRE(all_args.size() == 1);
+    REQUIRE(all_args[0]->name() == "ARG");
+}


### PR DESCRIPTION
The all_options, all_arguments and all_commands methods returned the objects belonging to the top-level command (ArgumentParser), not the current sub-command.