### PR TITLE
Fix two bugs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # ===========================================================================
 cmake_minimum_required(VERSION 3.16)
 
-project(Argos VERSION 1.6.0)
+project(Argos VERSION 1.6.1)
 
 set(CMAKE_CXX_STANDARD 20)
 

--- a/single_src/Argos/Argos.hpp
+++ b/single_src/Argos/Argos.hpp
@@ -15,7 +15,7 @@
 /**
  * @brief String representation of the complete version number.
  */
-constexpr char ARGOS_VERSION[] = "1.6.0";
+constexpr char ARGOS_VERSION[] = "1.6.1";
 
 /**
  * @brief Incremented when a new version contains significant changes. It
@@ -33,7 +33,7 @@ constexpr char ARGOS_VERSION[] = "1.6.0";
 /**
  * @brief Incremented when the changes does not affect the interface.
  */
-#define ARGOS_VERSION_PATCH 0
+#define ARGOS_VERSION_PATCH 1
 
 //****************************************************************************
 // Copyright © 2020 Jan Erik Breimo. All rights reserved.


### PR DESCRIPTION
- Make sure the top-level parsed arguments returns SUCCESS when the final sub-command has been
  parsed successfully.
- Start looking for the next sub-command as soon as the current one has received its minimum number of arguments.