### PR TITLE
feature/mutable_list_of_args

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # ===========================================================================
 cmake_minimum_required(VERSION 3.16)
 
-project(Argos VERSION 1.6.2)
+project(Argos VERSION 1.99.0)
 
 set(CMAKE_CXX_STANDARD 20)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # ===========================================================================
 cmake_minimum_required(VERSION 3.16)
 
-project(Argos VERSION 1.99.0)
+project(Argos VERSION 1.7.0)
 
 set(CMAKE_CXX_STANDARD 20)
 

--- a/examples/table/table.cpp
+++ b/examples/table/table.cpp
@@ -28,19 +28,19 @@ int main(int argc, char* argv[])
         .about("Prints the arguments as cells in a table. The program also"
                " demonstrates one way to use option and argument callbacks.")
         .add(Arg("TEXT").count(1, UINT16_MAX)
-            .callback([&](auto, auto text, auto)
+            .callback([&](auto& a)
                       {
-                          cells.push_back({std::string(text), row, col});
+                          cells.push_back({std::string(a.value), row, col});
                           ++col;
                       })
             .help("Text of the next table cell."))
         .add(Opt{"-o", "--output"}.argument("FILE")
             .help("File name for output. stdout is used by default."))
         .add(Opt{"-r", "--row"}
-            .callback([&](auto, auto, auto){++row; col = 0;})
+            .callback([&](auto&){++row; col = 0;})
             .help("Next file will be placed at the beginning of a new row."))
         .add(Opt{"-c", "--column"}
-            .callback([&](auto, auto, auto){++col;})
+            .callback([&](auto&){++col;})
             .help("Skip one column forward."))
         .add(Opt{"--borders"}.help("Print borders between cells."))
         .parse(argc, argv);

--- a/include/Argos/Callbacks.hpp
+++ b/include/Argos/Callbacks.hpp
@@ -19,42 +19,71 @@
 namespace argos
 {
     /**
+     * @brief The parameter type for argument and option callbacks.
+     * @tparam ViewT Either ArgumentView or OptionView.
+     */
+    template <typename ViewT>
+    struct CallbackArguments
+    {
+        /**
+         * The argument or option that was encountered.
+         * Is an instance of either ArgumentView or OptionView.
+         */
+        ViewT view;
+
+        /**
+         * The value of the argument or the option's argument, if any.
+         */
+        std::string_view value;
+
+        /**
+         * Gives access to the arguments and options processed so far. Can be
+         * used to get or set the values of arguments and options.
+         */
+        ParsedArgumentsBuilder builder;
+
+        /**
+         * Add new arguments to the command line that is being parsed. These
+         * arguments are inserted immediately after the current argument
+         * and can be anything, including options and
+         * commands.
+         */
+        std::vector<std::string> new_arguments;
+
+        CallbackArguments(const ViewT& view,
+                          std::string_view value,
+                          std::shared_ptr<ParsedArgumentsImpl> impl)
+            : view(view),
+              value(value),
+              builder(std::move(impl))
+        {
+        }
+    };
+
+    /**
+     * @brief The parameter type for argument callbacks.
+     */
+    using ArgumentCallbackArguments = CallbackArguments<ArgumentView>;
+
+    /**
      * @brief A callback that is called each time given arguments appear
      *      on the command line.
-     *
-     * The three parameters are:
-     * - ArgumentView: the argument that was encountered (particularly
-     *   useful if the same function has been registered with multiple
-     *   arguments).
-     * - std::string_view: the raw value of the argument. Note that this
-     *   value can also be retrieved via the ParsedArgumentsBuilder.
-     * - ParsedArgumentsBuilder: this object can be used to read or modify
-     *   the values of arguments and options.
      */
-    using ArgumentCallback = std::function<void(ArgumentView,
-                                                std::string_view,
-                                                ParsedArgumentsBuilder)>;
+    using ArgumentCallback = std::function<void(ArgumentCallbackArguments&)>;
+
+    /**
+     * @brief The parameter type for option callbacks.
+     */
+    using OptionCallbackArguments = CallbackArguments<OptionView>;
 
     /**
      * @brief A callback that is called each time given options appear
      *      on the command line.
-     *
-     * The three parameters are:
-     * - OptionView: the option that was encountered (particularly
-     *   useful if the same function has been registered with multiple
-     *   options).
-     * - std::string_view: the raw value of the option if the option actually
-     *   has one. Note that this value can also be retrieved via the
-     *   ParsedArgumentsBuilder if the option operation is ASSIGN or APPEND.
-     * - ParsedArgumentsBuilder: this object can be used to read or modify
-     *   the values of arguments and options.
      */
-    using OptionCallback = std::function<void(OptionView,
-                                              std::string_view,
-                                              ParsedArgumentsBuilder)>;
+    using OptionCallback = std::function<void(OptionCallbackArguments&)>;
 
     /**
-     * @brief A callback that is meant to return a part of the help text.
+     * @brief A callback that returns a part of the help text.
      */
     using TextCallback = std::function<std::string()>;
 }

--- a/single_src/Argos/Argos.hpp
+++ b/single_src/Argos/Argos.hpp
@@ -15,7 +15,7 @@
 /**
  * @brief String representation of the complete version number.
  */
-constexpr char ARGOS_VERSION[] = "1.99.0";
+constexpr char ARGOS_VERSION[] = "1.7.0";
 
 /**
  * @brief Incremented when a new version contains significant changes. It
@@ -28,7 +28,7 @@ constexpr char ARGOS_VERSION[] = "1.99.0";
  * @brief Incremented when Argos's interface is modified in ways that are
  *  compatible with existing client code.
  */
-#define ARGOS_VERSION_MINOR 99
+#define ARGOS_VERSION_MINOR 7
 
 /**
  * @brief Incremented when the changes does not affect the interface.

--- a/single_src/Argos/Argos.hpp
+++ b/single_src/Argos/Argos.hpp
@@ -15,7 +15,7 @@
 /**
  * @brief String representation of the complete version number.
  */
-constexpr char ARGOS_VERSION[] = "1.6.2";
+constexpr char ARGOS_VERSION[] = "1.99.0";
 
 /**
  * @brief Incremented when a new version contains significant changes. It
@@ -28,12 +28,12 @@ constexpr char ARGOS_VERSION[] = "1.6.2";
  * @brief Incremented when Argos's interface is modified in ways that are
  *  compatible with existing client code.
  */
-#define ARGOS_VERSION_MINOR 6
+#define ARGOS_VERSION_MINOR 99
 
 /**
  * @brief Incremented when the changes does not affect the interface.
  */
-#define ARGOS_VERSION_PATCH 2
+#define ARGOS_VERSION_PATCH 0
 
 //****************************************************************************
 // Copyright © 2020 Jan Erik Breimo. All rights reserved.
@@ -2010,42 +2010,71 @@ namespace argos
 namespace argos
 {
     /**
+     * @brief The parameter type for argument and option callbacks.
+     * @tparam ViewT Either ArgumentView or OptionView.
+     */
+    template <typename ViewT>
+    struct CallbackArguments
+    {
+        /**
+         * The argument or option that was encountered.
+         * Is an instance of either ArgumentView or OptionView.
+         */
+        ViewT view;
+
+        /**
+         * The value of the argument or the option's argument, if any.
+         */
+        std::string_view value;
+
+        /**
+         * Gives access to the arguments and options processed so far. Can be
+         * used to get or set the values of arguments and options.
+         */
+        ParsedArgumentsBuilder builder;
+
+        /**
+         * Add new arguments to the command line that is being parsed. These
+         * arguments are inserted immediately after the current argument
+         * and can be anything, including options and
+         * commands.
+         */
+        std::vector<std::string> new_arguments;
+
+        CallbackArguments(const ViewT& view,
+                          std::string_view value,
+                          std::shared_ptr<ParsedArgumentsImpl> impl)
+            : view(view),
+              value(value),
+              builder(std::move(impl))
+        {
+        }
+    };
+
+    /**
+     * @brief The parameter type for argument callbacks.
+     */
+    using ArgumentCallbackArguments = CallbackArguments<ArgumentView>;
+
+    /**
      * @brief A callback that is called each time given arguments appear
      *      on the command line.
-     *
-     * The three parameters are:
-     * - ArgumentView: the argument that was encountered (particularly
-     *   useful if the same function has been registered with multiple
-     *   arguments).
-     * - std::string_view: the raw value of the argument. Note that this
-     *   value can also be retrieved via the ParsedArgumentsBuilder.
-     * - ParsedArgumentsBuilder: this object can be used to read or modify
-     *   the values of arguments and options.
      */
-    using ArgumentCallback = std::function<void(ArgumentView,
-                                                std::string_view,
-                                                ParsedArgumentsBuilder)>;
+    using ArgumentCallback = std::function<void(ArgumentCallbackArguments&)>;
+
+    /**
+     * @brief The parameter type for option callbacks.
+     */
+    using OptionCallbackArguments = CallbackArguments<OptionView>;
 
     /**
      * @brief A callback that is called each time given options appear
      *      on the command line.
-     *
-     * The three parameters are:
-     * - OptionView: the option that was encountered (particularly
-     *   useful if the same function has been registered with multiple
-     *   options).
-     * - std::string_view: the raw value of the option if the option actually
-     *   has one. Note that this value can also be retrieved via the
-     *   ParsedArgumentsBuilder if the option operation is ASSIGN or APPEND.
-     * - ParsedArgumentsBuilder: this object can be used to read or modify
-     *   the values of arguments and options.
      */
-    using OptionCallback = std::function<void(OptionView,
-                                              std::string_view,
-                                              ParsedArgumentsBuilder)>;
+    using OptionCallback = std::function<void(OptionCallbackArguments&)>;
 
     /**
-     * @brief A callback that is meant to return a part of the help text.
+     * @brief A callback that returns a part of the help text.
      */
     using TextCallback = std::function<std::string()>;
 }

--- a/src/Argos/ArgumentCounter.cpp
+++ b/src/Argos/ArgumentCounter.cpp
@@ -89,10 +89,16 @@ namespace argos
     }
 
     ArgumentCounter::ArgumentCounter(const CommandData& command,
-                                     size_t argument_count)
+                                     size_t argument_count,
+                                     size_t initial_count)
         : m_counters(make_argument_counters(command, argument_count)),
           m_first_optional(m_counters.size())
     {
+        for (size_t i = 0; i < initial_count; ++i)
+        {
+            if (next_argument() == nullptr)
+                break;
+        }
     }
 
     const ArgumentData* ArgumentCounter::next_argument()

--- a/src/Argos/ArgumentCounter.hpp
+++ b/src/Argos/ArgumentCounter.hpp
@@ -19,7 +19,9 @@ namespace argos
 
         explicit ArgumentCounter(const CommandData& command);
 
-        ArgumentCounter(const CommandData& command, size_t argument_count);
+        ArgumentCounter(const CommandData& command,
+                        size_t argument_count,
+                        size_t initial_count = 0);
 
         const ArgumentData* next_argument();
 

--- a/src/Argos/ArgumentIteratorImpl.hpp
+++ b/src/Argos/ArgumentIteratorImpl.hpp
@@ -88,6 +88,8 @@ namespace argos
 
         void reactivate_multi_command_parent(size_t index);
 
+        void update_arguments(const std::vector<std::string>& args);
+
         void error(const std::string& message = {});
 
         std::shared_ptr<ParserData> m_data;

--- a/src/Argos/OptionIterator.cpp
+++ b/src/Argos/OptionIterator.cpp
@@ -17,7 +17,7 @@ namespace argos
     }
 
     OptionIterator::OptionIterator(std::vector<std::string_view> args, char prefix)
-        : m_all_args(std::move(args)),
+        : m_all_args(args.begin(), args.end()),
           m_args(m_all_args),
           m_prefix(prefix)
     {
@@ -89,8 +89,19 @@ namespace argos
         return m_args[0];
     }
 
-    std::span<std::string_view> OptionIterator::remaining_arguments() const
+    std::span<std::string> OptionIterator::remaining_arguments() const
     {
         return m_pos == 0 ? m_args : m_args.subspan(1);
+    }
+
+    void OptionIterator::insert(const std::vector<std::string>& args)
+    {
+        auto args_index = m_all_args.size() - m_args.size();
+        auto insert_index = args_index;
+        if (m_pos != 0)
+            insert_index++;
+        m_all_args.insert(m_all_args.begin() + insert_index,
+                          args.begin(), args.end());
+        m_args = std::span(m_all_args.begin() + args_index, m_all_args.end());
     }
 }

--- a/src/Argos/OptionIterator.hpp
+++ b/src/Argos/OptionIterator.hpp
@@ -30,10 +30,12 @@ namespace argos
 
         [[nodiscard]] std::string_view current() const;
 
-        [[nodiscard]] std::span<std::string_view> remaining_arguments() const;
+        [[nodiscard]] std::span<std::string> remaining_arguments() const;
+
+        void insert(const std::vector<std::string>& args);
     private:
-        std::vector<std::string_view> m_all_args;
-        std::span<std::string_view> m_args;
+        std::vector<std::string> m_all_args;
+        std::span<std::string> m_args;
         size_t m_pos = 0;
         char m_prefix = '-';
     };

--- a/src/Argos/OptionIteratorWrapper.hpp
+++ b/src/Argos/OptionIteratorWrapper.hpp
@@ -38,12 +38,20 @@ namespace argos
                 return std::get<StandardOptionIterator>(iterator).current();
         }
 
-        [[nodiscard]] std::span<std::string_view> remaining_arguments() const
+        [[nodiscard]] std::span<std::string> remaining_arguments()
         {
             if (std::holds_alternative<OptionIterator>(iterator))
                 return std::get<OptionIterator>(iterator).remaining_arguments();
             else
                 return std::get<StandardOptionIterator>(iterator).remaining_arguments();
+        }
+
+        void insert(const std::vector<std::string>& args)
+        {
+            if (std::holds_alternative<OptionIterator>(iterator))
+                std::get<OptionIterator>(iterator).insert(args);
+            else
+                std::get<StandardOptionIterator>(iterator).insert(args);
         }
 
         std::variant<OptionIterator, StandardOptionIterator> iterator;

--- a/src/Argos/ParsedArgumentsImpl.cpp
+++ b/src/Argos/ParsedArgumentsImpl.cpp
@@ -18,8 +18,8 @@ namespace argos
 {
     namespace
     {
-        template <typename It, typename Value, typename IsLess>
-        It lower_bound(It begin, It end, Value&& v, IsLess is_less)
+        template <typename ItT, typename ValueT, typename IsLessT>
+        ItT lower_bound(ItT begin, ItT end, ValueT&& v, IsLessT is_less)
         {
             while (begin != end)
             {

--- a/src/Argos/ParserData.cpp
+++ b/src/Argos/ParserData.cpp
@@ -46,9 +46,9 @@ namespace argos
                 .help("Display the program version.")
                 .constant("1")
                 .callback([v = data.version, stream]
-                (auto, auto, auto pa)
+                (auto& a)
                     {
-                        *stream << pa.program_name() << " " << v << "\n";
+                        *stream << a.builder.program_name() << " " << v << "\n";
                         return true;
                     })
                 .release();

--- a/src/Argos/StandardOptionIterator.hpp
+++ b/src/Argos/StandardOptionIterator.hpp
@@ -29,10 +29,14 @@ namespace argos
 
         [[nodiscard]] std::string_view current() const;
 
-        [[nodiscard]] std::span<std::string_view> remaining_arguments() const;
+        [[nodiscard]] std::span<std::string> remaining_arguments();
+
+        void insert(std::vector<std::string> args);
     private:
-        std::vector<std::string_view> m_all_args;
-        std::span<std::string_view> m_args;
+        void split_concatenated_flags();
+
+        std::vector<std::string> m_all_args;
+        std::span<std::string> m_args;
         size_t m_pos = 0;
     };
 }

--- a/src/Argos/StringUtilities.hpp
+++ b/src/Argos/StringUtilities.hpp
@@ -48,7 +48,8 @@ namespace argos
 
     bool is_lower(std::string_view word);
 
-    inline void pop_front(std::span<std::string_view>& span)
+    template <typename T>
+    inline void pop_front(std::span<T>& span)
     {
         span = span.subspan(1);
     }

--- a/tests/ArgosTest/CMakeLists.txt
+++ b/tests/ArgosTest/CMakeLists.txt
@@ -16,19 +16,20 @@ FetchContent_MakeAvailable(catch)
 
 add_executable(ArgosTest
     Argv.hpp
+    U8Adapter.hpp
     test_ArgumentCounter.cpp
     test_ArgumentParser.cpp
     test_ArgumentValue.cpp
+    test_Callbacks.cpp
     test_HelpWriter.cpp
-    test_ParsedArguments.cpp
     test_ParseValue.cpp
+    test_ParsedArguments.cpp
     test_StandardOptionIterator.cpp
     test_StringUtilities.cpp
+    test_Subcommands.cpp
     test_TextFormatter.cpp
     test_TextWriter.cpp
     test_WordSplitter.cpp
-    test_Subcommands.cpp
-    U8Adapter.hpp
 )
 
 target_link_libraries(ArgosTest

--- a/tests/ArgosTest/test_ArgumentParser.cpp
+++ b/tests/ArgosTest/test_ArgumentParser.cpp
@@ -443,46 +443,6 @@ TEST_CASE("Abbreviated options")
     }
 }
 
-TEST_CASE("Test option callback")
-{
-    using namespace argos;
-    Argv argv{"test", "-a"};
-    ArgumentParser parser("test");
-    auto args = parser.auto_exit(false)
-        .add(Option({"-b"}))
-        .add(Option({"-c"}))
-        .add(Option({"-a"}).callback(
-            [](auto opt, auto, auto builder) -> bool
-            {
-                builder.assign("-b", "true").assign("-c", "true");
-                return true;
-            }))
-        .parse(argv.size(), argv.data());
-    REQUIRE(args.result_code() == ParserResultCode::SUCCESS);
-    REQUIRE(args.value("-a").as_bool());
-    REQUIRE(args.value("-b").as_bool());
-    REQUIRE(args.value("-c").as_bool());
-}
-
-TEST_CASE("Test argument callback")
-{
-    using namespace argos;
-    Argv argv{"test", "-b", "abcd"};
-    ArgumentParser parser("test");
-    auto args = parser.auto_exit(false)
-        .add(Option({"-b"}))
-        .add(Argument("arg").callback(
-            [](auto arg, auto, auto builder) -> bool
-            {
-                builder.assign("-b", "false");
-                return true;
-            }))
-        .parse(argv.size(), argv.data());
-    REQUIRE(args.result_code() == ParserResultCode::SUCCESS);
-    REQUIRE(!args.value("-b").as_bool());
-    REQUIRE(args.value("arg").as_string() == "abcd");
-}
-
 TEST_CASE("Two arguments with the same name")
 {
     using namespace argos;

--- a/tests/ArgosTest/test_Callbacks.cpp
+++ b/tests/ArgosTest/test_Callbacks.cpp
@@ -1,0 +1,136 @@
+//****************************************************************************
+// Copyright © 2025 Jan Erik Breimo. All rights reserved.
+// Created by Jan Erik Breimo on 2025-01-19.
+//
+// This file is distributed under the Zero-Clause BSD License.
+// License text is included with the source distribution.
+//****************************************************************************
+#include <catch2/catch_test_macros.hpp>
+#include "Argos/ArgumentParser.hpp"
+#include "Argv.hpp"
+
+TEST_CASE("Test option callback")
+{
+    using namespace argos;
+    Argv argv{"test", "-a"};
+    auto args = ArgumentParser()
+        .auto_exit(false)
+        .add(Option({"-b"}))
+        .add(Option({"-c"}))
+        .add(Option({"-a"}).callback(
+            [](auto& oa) -> bool
+            {
+                oa.builder.assign("-b", "true").assign("-c", "true");
+                return true;
+            }))
+        .parse(argv.size(), argv.data());
+    REQUIRE(args.result_code() == ParserResultCode::SUCCESS);
+    REQUIRE(args.value("-a").as_bool());
+    REQUIRE(args.value("-b").as_bool());
+    REQUIRE(args.value("-c").as_bool());
+}
+
+TEST_CASE("Test argument callback")
+{
+    using namespace argos;
+    Argv argv{"test", "-b", "abcd"};
+    auto args = ArgumentParser()
+        .auto_exit(false)
+        .add(Option({"-b"}))
+        .add(Argument("arg").callback(
+            [](auto aa) -> bool
+            {
+                aa.builder.assign("-b", "false");
+                return true;
+            }))
+        .parse(argv.size(), argv.data());
+    REQUIRE(args.result_code() == ParserResultCode::SUCCESS);
+    REQUIRE(!args.value("-b").as_bool());
+    REQUIRE(args.value("arg").as_string() == "abcd");
+}
+
+TEST_CASE("Callback for all options")
+{
+    using namespace argos;
+    struct Callback
+    {
+        Callback(size_t& i) : i(i) {}
+        void operator()(OptionCallbackArguments& oa)
+        {
+            REQUIRE(i != values.size());
+            REQUIRE(oa.view.flags().size() == 1);
+            REQUIRE(oa.view.flags()[0] == values[i]);
+            ++i;
+        }
+
+        size_t& i;
+        std::array<std::string, 2> values = {"-b", "-c"};
+    };
+
+    size_t i = 0;
+    Argv argv{"test", "-b", "-c"};
+    auto args = ArgumentParser()
+        .auto_exit(false)
+        .add(Option("-b"))
+        .add(Option("-c"))
+        .option_callback(Callback(i))
+        .parse(argv.size(), argv.data());
+    REQUIRE(i == 2);
+}
+
+TEST_CASE("Callback for all arguments")
+{
+    using namespace argos;
+    struct Callback
+    {
+        Callback(size_t& i)
+            : i(i)
+        {
+        }
+
+        void operator()(ArgumentCallbackArguments& oa)
+        {
+            REQUIRE(i != values.size());
+            REQUIRE(oa.view.name() == values[i]);
+            ++i;
+        }
+
+        size_t& i;
+        std::array<std::string, 2> values = {"FILE", "URL"};
+    };
+
+    size_t i = 0;
+    Argv argv{"test", "bbb", "ccc"};
+    auto args = ArgumentParser()
+        .auto_exit(false)
+        .add(Argument("FILE"))
+        .add(Argument("URL"))
+        .argument_callback(Callback(i))
+        .parse(argv.size(), argv.data());
+    REQUIRE(i == 2);
+}
+
+TEST_CASE("Test option callback adding new args")
+{
+    using namespace argos;
+    Argv argv{"test", "-aC"};
+    auto args = ArgumentParser()
+        .auto_exit(false)
+        .add(Option({"-b"}))
+        .add(Option({"-B"}).alias("-b").constant(false))
+        .add(Option({"-c"}))
+        .add(Option({"-C"}).alias("-c").constant(false))
+        .add(Option({"-d"}))
+        .add(Option({"-D"}).alias("-d").constant(false))
+        .add(Option({"-a"}).callback(
+            [](auto& oa)
+            {
+                oa.new_arguments = {"-bcd"};
+            }))
+        .parse(argv.size(), argv.data());
+    REQUIRE(args.result_code() == ParserResultCode::SUCCESS);
+    REQUIRE(args.value("-a").as_bool());
+    REQUIRE(args.value("-b").as_bool());
+    REQUIRE_FALSE(args.value("-c").as_bool());
+    REQUIRE(args.value("-d").as_bool());
+}

--- a/tests/ArgosTest/test_Callbacks.cpp
+++ b/tests/ArgosTest/test_Callbacks.cpp
@@ -64,7 +64,7 @@ TEST_CASE("Callback for all options")
         }
 
         size_t& i;
-        std::array<std::string, 2> values = {"-b", "-c"};
+        std::array<std::string, 2> values = {{"-b", "-c"}};
     };
 
     size_t i = 0;
@@ -96,7 +96,7 @@ TEST_CASE("Callback for all arguments")
         }
 
         size_t& i;
-        std::array<std::string, 2> values = {"FILE", "URL"};
+        std::array<std::string, 2> values = {{"FILE", "URL"}};
     };
 
     size_t i = 0;

--- a/tests/ArgosTest/test_Callbacks.cpp
+++ b/tests/ArgosTest/test_Callbacks.cpp
@@ -5,6 +5,7 @@
 // This file is distributed under the Zero-Clause BSD License.
 // License text is included with the source distribution.
 //****************************************************************************
+#include <array>
 #include <catch2/catch_test_macros.hpp>
 #include "Argos/ArgumentParser.hpp"
 #include "Argv.hpp"
@@ -64,7 +65,7 @@ TEST_CASE("Callback for all options")
         }
 
         size_t& i;
-        std::array<std::string, 2> values = {{"-b", "-c"}};
+        std::array<std::string, 2> values = {"-b", "-c"};
     };
 
     size_t i = 0;
@@ -96,7 +97,7 @@ TEST_CASE("Callback for all arguments")
         }
 
         size_t& i;
-        std::array<std::string, 2> values = {{"FILE", "URL"}};
+        std::array<std::string, 2> values = {"FILE", "URL"};
     };
 
     size_t i = 0;


### PR DESCRIPTION
Make it possible to modify the command line arguments that are currently being processed from callbacks. This is convenient in at least two situations:

- when one option "expands" to multiple other options or even commands
- when an option's callback reads default options or arguments from a file, an environment variable or similar.

This PR modifies the signature of callbacks and requires changes to existing use of them. 